### PR TITLE
Slightly more responsive design, for phone reading

### DIFF
--- a/theme/hlt/static/css/main.css
+++ b/theme/hlt/static/css/main.css
@@ -533,3 +533,21 @@ tbody tr td:nth-child(2) {
 tbody tr td:nth-child(3) {
   padding-left: 1em;
 }
+@media only screen and (max-device-width: 640px) {
+  article div.content, p#article-abstract, figure.code figcaption, article img, 
+  article p#article-meta, article div.related, .content-list, #article-list,
+  #author-list, #tag-list, #category-list, .paginator, footer, figcaption.image-caption {
+    width: auto;
+  }
+  blockquote {
+    margin: 48px 12px;
+    padding-bottom: 20px;
+    font-size: 1.2em;
+    line-height: 1.2;
+  }
+  figcaption.image-caption {
+    position: static;
+    line-height: 1;
+  }
+
+}

--- a/theme/hlt/templates/base.html
+++ b/theme/hlt/templates/base.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <title>{% block title %}{{ SITENAME }}{%endblock%}</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
         <meta charset="utf-8" />
         {% block meta_other %}{% endblock %}


### PR DESCRIPTION
Add a meta viewport, and explicitly turn off hardcoded width:650px on loads of stuff, in order to make it display more nicely on narrow screens such as phones.